### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "catppuccin": {
       "locked": {
-        "lastModified": 1730036420,
-        "narHash": "sha256-rv2bz7J6Wo7AenPiu4+ptCB1AFyaMcS77y89zbRAtI8=",
+        "lastModified": 1730458408,
+        "narHash": "sha256-JQ+SphQn13bdibKUrBBBznYehXX4xJrxD1ifBp6vSWw=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "0b7bf04628414a402d255924f65e9a0d1a53d92b",
+        "rev": "191fbf2d81a63fad8f62f1233c0051f09b75d0ad",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730016908,
-        "narHash": "sha256-bFCxJco7d8IgmjfNExNz9knP8wvwbXU4s/d53KOK6U0=",
+        "lastModified": 1730633670,
+        "narHash": "sha256-ZFJqIXpvVKvzOVFKWNRDyIyAo+GYdmEPaYi1bZB6uf0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83414058edd339148dc142a8437edb9450574c8",
+        "rev": "8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1729068498,
-        "narHash": "sha256-C2sGRJl1EmBq0nO98TNd4cbUy20ABSgnHWXLIJQWRFA=",
+        "lastModified": 1730403150,
+        "narHash": "sha256-W1FH5aJ/GpRCOA7DXT/sJHFpa5r8sq2qAUncWwRZ3Gg=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "e337457502571b23e449bf42153d7faa10c0a562",
+        "rev": "0d09341beeaa2367bac5d718df1404bf2ce45e6f",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730366568,
-        "narHash": "sha256-/fKbewYJlo1kacBb+PotoleqzU2uO7wsHzg+BcxVjOM=",
+        "lastModified": 1730537918,
+        "narHash": "sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4048e9ce2d8b054a7325e573371ede8995d397a1",
+        "rev": "f6e0cd5c47d150c4718199084e5764f968f1b560",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1730531603,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1729973466,
-        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
+        "lastModified": 1730602179,
+        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
+        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1729951556,
-        "narHash": "sha256-bpb6r3GjzhNW8l+mWtRtLNg5PhJIae041sPyqcFNGb4=",
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4e0eec54db79d4d0909f45a88037210ff8eaffee",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1729999681,
-        "narHash": "sha256-qm0uCtM9bg97LeJTKQ8dqV/FvqRN+ompyW4GIJruLuw=",
+        "lastModified": 1730605784,
+        "narHash": "sha256-1NveNAMLHbxOg0BpBMSVuZ2yW2PpDnZLbZ25wV50PMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1666d16426abe79af5c47b7c0efa82fd31bf4c56",
+        "rev": "e9b5eef9b51cdf966c76143e13a9476725b2f760",
         "type": "github"
       },
       "original": {

--- a/modules/hm/default.nix
+++ b/modules/hm/default.nix
@@ -7,7 +7,8 @@
     packages = with pkgs; [
       alejandra
       # bitwig-studio
-      blender
+      # https://github.com/NixOS/nixpkgs/issues/352873
+      # blender
       brightnessctl
       # Failing to build
       # calibre

--- a/modules/nixos/optional/media-server.nix
+++ b/modules/nixos/optional/media-server.nix
@@ -1,6 +1,8 @@
 {
-  services.jellyfin = {
-    enable = true;
-    openFirewall = true;
-  };
+  # https://github.com/NixOS/nixpkgs/issues/353600
+
+  # services.jellyfin = {
+  #   enable = true;
+  #   openFirewall = true;
+  # };
 }


### PR DESCRIPTION
Automated update of flake inputs.

Some builds failed:


### Build failed for zoidberg:

```
       > patching file pxr/imaging/plugin/hdEmbree/mesh.h
       > Hunk #1 succeeded at 15 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/meshSamplers.h
       > Hunk #1 succeeded at 12 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/pch.h
       > Hunk #1 FAILED at 151.
       > 1 out of 1 hunk FAILED -- saving rejects to file pxr/imaging/plugin/hdEmbree/pch.h.rej
       > patching file pxr/imaging/plugin/hdEmbree/renderDelegate.h
       > Hunk #1 succeeded at 14 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/renderParam.h
       > Hunk #1 succeeded at 11 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/renderer.cpp
       > Hunk #1 succeeded at 636 (offset -14 lines).
       > Hunk #2 succeeded at 976 (offset -14 lines).
       > patching file pxr/imaging/plugin/hdEmbree/renderer.h
       > Hunk #1 succeeded at 15 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/testenv/testHdEmbree.cpp
       > Hunk #1 succeeded at 23 (offset -17 lines).
       For full logs, run 'nix log /nix/store/kwq8p25b3hawxphw8lk8n03l1g2mqnmf-python3.11-openusd-24.08.drv'.
error: 1 dependencies of derivation '/nix/store/50bzywiz9hpxckyd3fk18zypzf5wgfb1-blender-4.2.3.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1824la3063y8vv16x5pn3i9brcsmkk2x-blender-4.2.3-fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/3pinmyqi9dnli3jhcri1kb4f9m1x6649-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/x4c26pm95941q9qmawjrq94bvgsbp659-man-paths.drv' failed to build
building '/nix/store/530c8bblwvg806lxbkhys076xp6ml422-rofi-1.7.5-fish-completions.drv'...
building '/nix/store/9b1xvk5xzcj2m3gyvsbv1mz7dcrph2j8-shutdown-ramfs-contents.json.drv'...
building '/nix/store/pwpiqijcih2ahc7bbyjva2g4cb32a1pz-signal-desktop-7.31.0-fish-completions.drv'...
building '/nix/store/f9vghs5js6nkhg9ymlbfavdsffmymi5j-slack-4.41.97.drv'...
building '/nix/store/001186by0mn7hi9y62rbvnbvfa67g585-smpeg-0.4.5.drv'...
building '/nix/store/h8dy87ykm19isd4lhr3a1c76ys6jcvh7-smpeg2-unstable-2022-05-26.drv'...
building '/nix/store/1b620lz5wwhdmaggb43cckvbidk5j36h-sops-3.9.1_fish-completions.drv'...
building '/nix/store/yi97vw24hcy7d8zbl01axwqjisjdjxcl-sound-theme-freedesktop-0.8_fish-completions.drv'...
building '/nix/store/dd69n2l3pzj96qgja553cynscfz7bzxm-speech-dispatcher-0.11.5_fish-completions.drv'...
building '/nix/store/xbyzvmz1sx5l5m939s4rwr1qg2k241vl-spidermonkey-128.1.0.drv'...
building '/nix/store/dmmhsaddszh3czz73iv2s48f7cl5cij4-sshd.pam.drv'...
building '/nix/store/8h6syqv75qn35y30hgrlglq74arv0iy6-stage-2-init.sh.drv'...
error (ignored): error: cannot unlink '"/tmp/nix-build-spidermonkey-128.1.0.drv-0/build/firefox-128.1.0/image/test"': Directory not empty
error: 1 dependencies of derivation '/nix/store/afsfzq58d8g8yc79w40xhvjirnd1yrq3-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/sic4wvyv3qzb2nj3jhs4nf489d7pfsbf-user-environment.drv' failed to build
error: 1 dependencies of derivation '/nix/store/daarq0403zhsg7x5vp3vyk4rz4lh0k26-etc.drv' failed to build
building '/nix/store/4nq6vmz6z7p7f1cw148yd844vgzlr28n-tlp-1.7.0.drv'...
building '/nix/store/zrgp4xfaly23daag0w6ranimhv0n36qx-unit-script-initrd-find-nixos-closure-start.drv'...
building '/nix/store/k5x5gwlqslvg967sldql89a8fxls5cfr-unit-script-initrd-nixos-activation-start.drv'...
building '/nix/store/a6kf3b18sd5k8vjikkxj2x5inbh9xcmc-unit-systemd-tmpfiles-setup-sysroot.service.drv'...
building '/nix/store/xf23cwa8vrfndd33nzc1p6scsxldyqx8-unit-systemd-tmpfiles-setup.service.drv'...
building '/nix/store/gqsi0x1qygafz0p63awvx5ihnmhlsg6m-users-groups.json.drv'...
building '/nix/store/0y21sici4vn542mp5hs9gj705jn0mk9v-vendor-registry.drv'...
building '/nix/store/kh4qd314kbv1hrbv7bbh512z2jq74dk7-vendor-registry.drv'...
building '/nix/store/4v0p6ykbjll9fpyjbr2ahw0yhx244icl-xkb-console-keymap.drv'...
building '/nix/store/lcz26fivrl9adf19lqsdik3zxjdypsc1-xkb-validated.drv'...
error: 1 dependencies of derivation '/nix/store/a472shvd8vjvfn1sxnf10qpj8mlpzqdh-nixos-system-zoidberg-24.11.20241102.7ffd9ae.drv' failed to build
```

### Build failed for hermes:

```
       > Hunk #1 FAILED at 151.
       > 1 out of 1 hunk FAILED -- saving rejects to file pxr/imaging/plugin/hdEmbree/pch.h.rej
       > patching file pxr/imaging/plugin/hdEmbree/renderDelegate.h
       > Hunk #1 succeeded at 14 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/renderParam.h
       > Hunk #1 succeeded at 11 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/renderer.cpp
       > Hunk #1 succeeded at 636 (offset -14 lines).
       > Hunk #2 succeeded at 976 (offset -14 lines).
       > patching file pxr/imaging/plugin/hdEmbree/renderer.h
       > Hunk #1 succeeded at 15 (offset -17 lines).
       > patching file pxr/imaging/plugin/hdEmbree/testenv/testHdEmbree.cpp
       > Hunk #1 succeeded at 23 (offset -17 lines).
       For full logs, run 'nix log /nix/store/kwq8p25b3hawxphw8lk8n03l1g2mqnmf-python3.11-openusd-24.08.drv'.
error: 1 dependencies of derivation '/nix/store/50bzywiz9hpxckyd3fk18zypzf5wgfb1-blender-4.2.3.drv' failed to build
copying path '/nix/store/zxprp02vmvnnlvwr4rxf6xwd8ij25p92-python3-3.12.7-env' from 'https://cache.nixos.org'...
building '/nix/store/zay217f1ijgjlypgmqxjy6031ihhcx9q-X-Restart-Triggers-nix-daemon.drv'...
error: 1 dependencies of derivation '/nix/store/1824la3063y8vv16x5pn3i9brcsmkk2x-blender-4.2.3-fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/2k1vfz7xvdsyjqlzzrrm29hjwzd65i3y-home-manager-path.drv' failed to build
building '/nix/store/0kjh0726bk1mkn1pqbmiwq96zsgl1w37-ledger-live-desktop-2.89.1-bwrap.drv'...
building '/nix/store/882znfbsdkxagb7hacd6j779ly6fw4ig-logue-cli-0.07-2b.drv'...
error: 1 dependencies of derivation '/nix/store/pbp8sgdmz3p675mrwab4nygmhk6b8pjb-man-paths.drv' failed to build
building '/nix/store/xbyzvmz1sx5l5m939s4rwr1qg2k241vl-spidermonkey-128.1.0.drv'...
building '/nix/store/hjgv7cj2g462k997b7rg3c2illa8c7wl-sshd.pam.drv'...
building '/nix/store/iziazv86gy39swl41cg3x6m20k7ws90f-starship-1.21.1-fish-completions.drv'...
building '/nix/store/yy5qd8fa02vdh2dz4pafgfsplplzkpmc-strace-6.11_fish-completions.drv'...
building '/nix/store/4mq510x4k77h506nza978l99jg55x5rs-string-hosts.drv'...
building '/nix/store/zn60jsjas95d9pjvg8f2fn2c0fcji8vc-su.pam.drv'...
building '/nix/store/pf2zvcrh0v4z3mp35nqpyypa7jzg24wl-sudo-1.9.15p5_fish-completions.drv'...
building '/nix/store/qk2yjx3c9yz22vh5v6dgppgq346wzqrc-sudo.pam.drv'...
building '/nix/store/mq40w667ym5jijr2yakdc9cxg0vin59d-sxhkd-0.6.2-fish-completions.drv'...
building '/nix/store/cwyc88iihsw217gkf58viwlsb5h82haf-syncthing-1.27.12-fish-completions.drv'...
building '/nix/store/l90xqyqnxs85gs771y0civxzcmf62a1v-system-generators.drv'...
building '/nix/store/y4aq32xnh4sp54rnmrld7d4spx09rfxs-system-shutdown.drv'...
error (ignored): error: cannot unlink '"/tmp/nix-build-spidermonkey-128.1.0.drv-1/build/firefox-128.1.0"': Directory not empty
building '/nix/store/kbk3qnbnjvqw4aw98fxfxyd70ly169ga-fc-cache.drv'...
error: 1 dependencies of derivation '/nix/store/jnpqp5rljgfdvdd3g14fzw8yd6k8cglj-home-manager-generation.drv' failed to build
building '/nix/store/kz8l1n6gcs5xy6j9qkakxq2a820ccb6i-unit-generate-shutdown-ramfs.service.drv'...
building '/nix/store/2mnj6vify63ld80g0dlhrfv62by1agfv-unit-systemd-modules-load.service.drv'...
error: 1 dependencies of derivation '/nix/store/ws1sfcnvy4czy9yhcpvl49z2s159n4hr-user-environment.drv' failed to build
error: 1 dependencies of derivation '/nix/store/yh3xs8yjpgh6fs1vr8ckkgjh35l354jp-etc.drv' failed to build
building '/nix/store/zrgp4xfaly23daag0w6ranimhv0n36qx-unit-script-initrd-find-nixos-closure-start.drv'...
building '/nix/store/k5x5gwlqslvg967sldql89a8fxls5cfr-unit-script-initrd-nixos-activation-start.drv'...
building '/nix/store/a6kf3b18sd5k8vjikkxj2x5inbh9xcmc-unit-systemd-tmpfiles-setup-sysroot.service.drv'...
building '/nix/store/xf23cwa8vrfndd33nzc1p6scsxldyqx8-unit-systemd-tmpfiles-setup.service.drv'...
building '/nix/store/0y21sici4vn542mp5hs9gj705jn0mk9v-vendor-registry.drv'...
building '/nix/store/kh4qd314kbv1hrbv7bbh512z2jq74dk7-vendor-registry.drv'...
building '/nix/store/4v0p6ykbjll9fpyjbr2ahw0yhx244icl-xkb-console-keymap.drv'...
building '/nix/store/lcz26fivrl9adf19lqsdik3zxjdypsc1-xkb-validated.drv'...
error: 1 dependencies of derivation '/nix/store/51wvmslv1daj0fgfk4h3zq7gx55vgiwr-nixos-system-hermes-24.11.20241102.7ffd9ae.drv' failed to build
```

### Build failed for farnsworth:

```
building '/nix/store/ndhgwddrqwp4wllcz7fmlz96mpdvzx42-homeassistant-2024.10.4.drv'...
building '/nix/store/h2yw63r0fsc9v5saj360jvmb8vzwxm44-user-units.drv'...
building '/nix/store/hcdmvwdmxhcqx5vw4lw5krha93csbys3-xkb-console-keymap.drv'...
building '/nix/store/c3x2li2dykmdacpyj7xm7kygv958577r-xlock.pam.drv'...
building '/nix/store/ipsmhw55xhfzg78czjjif6xf5vva6m89-xscreensaver.pam.drv'...
building '/nix/store/g4jf0si88fn8f2dkkav0vg8hwv6vmsg3-xz-5.6.3_fish-completions.drv'...
building '/nix/store/dldjd9y228ph27d0kfgq7d6qcazzwqnl-zstd-1.5.6_fish-completions.drv'...
building '/nix/store/zg5fjs6yh2bfqscp72w0jlyzi2h13pkr-keymap.drv'...
building '/nix/store/y25lqb4zpszxhrjzdizqgdjs6wsfjiaf-unit-systemd-udevd.service.drv'...
building '/nix/store/m8kg6j224nyyi51ilc9b779j5x897pdb-vconsole.conf.drv'...
building '/nix/store/xnsgbp8qkwkjg2h1qw2fn8h5anig04rs-stage-1-init.sh.drv'...
building '/nix/store/qp9cwrky35h192plxvw5h37fdpcc299y-system_fish-completions.drv'...
building '/nix/store/k0zrpblbzcps963pjliw7wc6g1zi7252-X-Restart-Triggers-reload-systemd-vconsole-setup.drv'...
building '/nix/store/9va5h75j0901kzn2qc4jlvyi35537q8a-unit-reload-systemd-vconsole-setup.service.drv'...
building '/nix/store/nnkhmcnij6kkzkd3dgjvr0my01630ywf-etc-man_db.conf.drv'...
building '/nix/store/gql6gshsxdhdy82al4d27i45d65kqpb1-initrd-linux-6.6.59.drv'...
building '/nix/store/pk5l8qww3rrgvy4rl1gwzxjyyv6gww6f-boot.json.drv'...
error: builder for '/nix/store/n9vd6qaiyzkyc8jf09ikr07k3vm9wxs2-jellyfin-ffmpeg-7.0.2-5.drv' failed with exit code 2;
       last 25 log lines:
       > CC     libavcodec/libvpxenc.o
       > CC      libavcodec/libwebpenc.o
       > CC     libavcodec/libwebpenc_animencoder.o
       > CC libavcodec/libwebpenc_common.o
       > CC      libavcodec/libx264.o
       > CC        libavcodec/libx265.o
       > CC        libavcodec/libxavs.o
       > CC        libavcodec/libxevd.o
       > CC        libavcodec/libxeve.o
       > CC        libavcodec/libxvid.o
       > CC        libavcodec/libzvbi-teletextdec.o
       > CC    libavcodec/ljpegenc.o
       > CC       libavcodec/loco.o
       > CC   libavcodec/lossless_audiodsp.o
       > CC      libavcodec/lossless_videodsp.o
       > libavcodec/libxeve.c: In function 'get_conf':
       > libavcodec/libxeve.c:199:27: error: incompatible types when assigning to type 'XEVE_RATIONAL' {aka 'struct _XEVE_RATIONAL'} from type 'long int'
       >   199 |         cdsc->param.fps = lrintf(av_q2d(avctx->framerate));
       >       |                           ^~~~~~
       > libavcodec/libxeve.c: In function 'libxeve_encode':
       > libavcodec/libxeve.c:484:40: error: incompatible types when assigning to type 'int' from type 'XEVE_RATIONAL' {aka 'struct _XEVE_RATIONAL'}
       >   484 |                 avpkt->time_base.den = xectx->cdsc.param.fps;
       >       |                                        ^~~~~
       > make: *** [ffbuild/common.mak:82: libavcodec/libxeve.o] Error 1
       > make: *** Waiting for unfinished jobs....
       For full logs, run 'nix log /nix/store/n9vd6qaiyzkyc8jf09ikr07k3vm9wxs2-jellyfin-ffmpeg-7.0.2-5.drv'.
error: 1 dependencies of derivation '/nix/store/s13zkd4ln6pppk3za5hvl7iq47zk77pq-jellyfin-10.10.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jdrd8r0vrqaligqydgs29rfr5lqbzkf7-unit-jellyfin.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/sc1w06n9x9ax6kybbi6zsga4yf2wjd3v-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/rylz594gh19piqgmrspvcffgz40j4iyr-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/p0kchr2gskgkbzzcqy9hv4pskkqiv2yj-nixos-system-farnsworth-24.11.20241102.7ffd9ae.drv' failed to build
```