### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "catppuccin": {
       "locked": {
-        "lastModified": 1730458408,
-        "narHash": "sha256-JQ+SphQn13bdibKUrBBBznYehXX4xJrxD1ifBp6vSWw=",
+        "lastModified": 1731088327,
+        "narHash": "sha256-Oizjf0wXBTqALipX4fQdGjq9IBSCXz8wwcfCGRK73bI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "191fbf2d81a63fad8f62f1233c0051f09b75d0ad",
+        "rev": "7bebd062df3239c005c0d600f5dfd8514f5915f8",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1730060262,
-        "narHash": "sha256-RMgSVkZ9H03sxC+Vh4jxtLTCzSjPq18UWpiM0gq6shQ=",
+        "lastModified": 1730652660,
+        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "498d9f122c413ee1154e8131ace5a35a80d8fa76",
+        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730633670,
-        "narHash": "sha256-ZFJqIXpvVKvzOVFKWNRDyIyAo+GYdmEPaYi1bZB6uf0=",
+        "lastModified": 1730837930,
+        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661",
+        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1730107060,
-        "narHash": "sha256-EnVVq1oNcimZmQYl6UlLYs0jhC6aLah0bsFMy2syEak=",
+        "lastModified": 1730739295,
+        "narHash": "sha256-aYeJ/P/9AuK6Kee63ZdsmDjEwhnksF+gIv/OyGtlBJE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0ad4ce46649b390da8bebcc229917f9863c98fe2",
+        "rev": "cef39a78679c266300874e7a7000b4da066228d4",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730537918,
-        "narHash": "sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8=",
+        "lastModified": 1730919458,
+        "narHash": "sha256-yMO0T0QJlmT/x4HEyvrCyigGrdYfIXX3e5gWqB64wLg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6e0cd5c47d150c4718199084e5764f968f1b560",
+        "rev": "e1cc1f6483393634aee94514186d21a4871e78d7",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730531603,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729996302,
-        "narHash": "sha256-QEU1NQq1+7s1na69Chig9K0iDDTKN0O4Zreo9A9rccA=",
+        "lastModified": 1730601085,
+        "narHash": "sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a1b337569f334ff0a01b57627f17b201d746d24c",
+        "rev": "8d1b40f8dfd7539aaa3de56e207e22b3cc451825",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730605784,
-        "narHash": "sha256-1NveNAMLHbxOg0BpBMSVuZ2yW2PpDnZLbZ25wV50PMc=",
+        "lastModified": 1731047660,
+        "narHash": "sha256-iyp51lPWEQz4c5VH9bVbAuBcFP4crETU2QJYh5V0NYA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e9b5eef9b51cdf966c76143e13a9476725b2f760",
+        "rev": "60e1bce1999f126e3b16ef45f89f72f0c3f8d16f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated update of flake inputs.

Some builds failed:


### Build failed for zoidberg:

```
building '/nix/store/q04syh72433a5926ycpjbjbkc06lb08b-sudo.pam.drv'...
building '/nix/store/kxca72l3vz1lyarcw57bswkwjbimhnah-systemd-user.pam.drv'...
copying path '/nix/store/267rdap7pn4wg03q2akrm5lx9xsls6rk-docker-27.3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/k3c7dhs1ag5vsa6nc2di68hsffd9pzg1-nixos-option' from 'https://cache.nixos.org'...
copying path '/nix/store/zjnhhixy3qrxmypym6c7sx0gr4vhjif6-nix-perl-2.24.10' from 'https://cache.nixos.org'...
copying path '/nix/store/kf8b42narlrx1aksha5l36ljqpyrqf7h-openscad-2021.01' from 'https://cache.nixos.org'...
copying path '/nix/store/vifr2dwa7g5ykbr8ldsqvz743sb9wplf-tbb-2021.11.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/qy7rfm4gzga4r12s9l08g7b9ca8r3n8a-systemd-256.7-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/qwzscsi3s9qvdhkm1vrwsr9jk3xahdcb-telegram-desktop-5.7.1' from 'https://cache.nixos.org'...
copying path '/nix/store/5y8md2c601wcb9k7hg58n39vh1j8m7a5-webkitgtk-2.46.3+abi=4.0' from 'https://cache.nixos.org'...
copying path '/nix/store/2zsjnfl8abg6ag2g4y9b1id67m5did31-timidity-2.15.0' from 'https://cache.nixos.org'...
building '/nix/store/s605axxfhixb1j48vw011ylsm06vxnv5-bootinstall.drv'...
building '/nix/store/vnln6b7w2jkibv60m2k4gxydasag659d-nix-2.24.10_fish-completions.drv'...
building '/nix/store/skrza5iyrny6bhv9fwfsw7q256q3q0pn-nix.conf.drv'...
building '/nix/store/gsqi8vafplwxwhfjy0kzaczmmgkbl1n0-nixos-help.drv'...
building '/nix/store/yw7kqrr96lh13nn032rhvhnbb08yx7cw-nixos-install.drv'...
building '/nix/store/sw0p03sgl5zxj33in9lplwr8xrv7qxfx-nixos-rebuild.drv'...
building '/nix/store/83pqag6x8rw84z3xqwrd7vc0gpnybv0c-unit-generate-shutdown-ramfs.service.drv'...
error: builder for '/nix/store/1gyqacwz41bhydifsnrgi993wn1881fz-expressvpnd-fhsenv-rootfs.drv' failed with exit code 1;
       last 2 log lines:
       > structuredAttrs is enabled
       > chmod: cannot access 'sbin': No such file or directory
       For full logs, run 'nix log /nix/store/1gyqacwz41bhydifsnrgi993wn1881fz-expressvpnd-fhsenv-rootfs.drv'.
copying path '/nix/store/n8l5vmax71m8hv1whzqinzy891gg2lqn-jellyfin-ffmpeg-7.0.2-5-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/0qx8vl2hmxg1nb3qs0vrv1wpjfk9r0b9-python3.12-remarshal-0.20.0' from 'https://cache.nixos.org'...
copying path '/nix/store/rfla4qp7acf49h235qh52ck0pvcx8hcr-yt-dlp-2024.11.4' from 'https://cache.nixos.org'...
copying path '/nix/store/cvsqvm3zgfcqkn5nsj7amqwrk25fs07l-zx-8.2.0' from 'https://cache.nixos.org'...
error: 1 dependencies of derivation '/nix/store/xqba5zf627x3skngv2m3qkk121f1gfyr-expressvpnd-bwrap.drv' failed to build
copying path '/nix/store/rdqs26hnhb163fi1naawp7cg2mlkma04-perl-5.40.0-env' from 'https://cache.nixos.org'...
building '/nix/store/5p1iiki6nhm58712f5yqbal91fyysl9b-NetworkManager-openconnect-1.2.10_fish-completions.drv'...
error: 1 dependencies of derivation '/nix/store/04r0grdsfb7lxvb0bhk2gf7rm2imssyf-expressvpnd.drv' failed to build
building '/nix/store/b3sfqx4dx4fp7rbj3hj3jwc3h2lxa4zs-sops-install-secrets-0.0.1.drv'...
building '/nix/store/2pk3609c27k179hw5ccawm6w4ibakbpk-unit-nh-clean.service.drv'...
building '/nix/store/sg89xxzy7kmv554avcll3cc8r61bd76j-unit-nix-optimise.service.drv'...
building '/nix/store/5i71klz3iizw9p6yyqjjfzpjw8rdzfsh-unit-script-nix-gc-start.drv'...
building '/nix/store/fcmnf37wwj0ajmmdr9m5s2l6swg026dg-unit-update-and-build.service.drv'...
building '/nix/store/dpqyp2lrlhmivfs7q2sy1zfipk9mid10-useradd.pam.drv'...
building '/nix/store/za7dyqxakbh7blsiy77r3y38khk36q7x-userdel.pam.drv'...
error: 1 dependencies of derivation '/nix/store/i4xmqcqhr6ny7b20aynzk1arp2cpcgfk-expressvpn-3.52.0.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/h99qphphpc9i461fhbx0vpacnqwdlpfk-expressvpn-3.52.0.2-fish-completions.drv' failed to build
building '/nix/store/j35bs2b82gdny4bw0rb89ndwajsw1jmc-fc-cache.drv'...
error: 1 dependencies of derivation '/nix/store/d4ipgwryh2x3skb7rpkjincchh8c8q4p-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/0pgi3p16rnzsqcvj4yyc3qpjq5k37ki1-man-paths.drv' failed to build
building '/nix/store/smg88620p1rz82r8vvqra76kp693f7pb-nixos-option_fish-completions.drv'...
building '/nix/store/fvig2bd6hfrh8njaplb84ia2f18h7mf7-openvdb-12.0.0.drv'...
error: 1 dependencies of derivation '/nix/store/kcv2y7ad3wprggn4vv4dfi0cv6f9rahr-unit-expressvpn.service.drv' failed to build
error (ignored): error: cannot unlink '"/tmp/nix-build-openvdb-12.0.0.drv-0/build/source"': Directory not empty
error: 1 dependencies of derivation '/nix/store/y2jn6mmj7gnhbgxsgwjyrk202d4j4a6f-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/nzhs31817kmy5203j3i61xpii0czgpvh-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8c04b57hqr3iqns125bqlbf7zmdsk2i7-nixos-system-zoidberg-24.11.20241105.4aa3656.drv' failed to build
```

### Build failed for hermes:

```
copying path '/nix/store/vs6xbc06kn1c3wp23xxnb1brr2q6r4ri-qemu-9.1.1-ga' from 'https://cache.nixos.org'...
building '/nix/store/fv0g0mlzrx9hhf00903d9nx39rcjwyaz-graphics-drivers.drv'...
copying path '/nix/store/dmvlf0j7sgyjf98w1kqwzsimhffq5r84-rdkafka-2.6.0' from 'https://cache.nixos.org'...
copying path '/nix/store/akvl4db43qwai772jmjk9g3wimyykb84-SDL2_mixer-2.8.0' from 'https://cache.nixos.org'...
copying path '/nix/store/6ai2r568mgh6ckv7dnwh0rjj6plag199-chromium-130.0.6723.91' from 'https://cache.nixos.org'...
copying path '/nix/store/q55c5isg6gkckxfkdxll1cr6ck6wkw7x-webkitgtk-2.46.3+abi=4.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/9gb558wd0wcfw9dax0vj7dg7a0didzkz-wxwidgets-3.1.7' from 'https://cache.nixos.org'...
copying path '/nix/store/bzdixncm642lm1kfh6n2ig0sdxdc64ri-ceph-19.2.0-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/jgaycm9h2xqb0nsf2zl4a44gxlybpylf-ledger-live-desktop-2.89.1-fhsenv-rootfs' from 'https://cache.nixos.org'...
copying path '/nix/store/mfspdcnr9ljiwvw5ixi29fzkrs8kk0n7-pinokio-1.3.4-fhsenv-rootfs' from 'https://cache.nixos.org'...
copying path '/nix/store/kz75q2inydsk05mb3ickzacarjxy32y1-playwright-chromium' from 'https://cache.nixos.org'...
building '/nix/store/f6vg4623qwjkygbjz6aaa4xplkbwyryg-SDL_ttf-2.0.11.drv'...
building '/nix/store/1xbnc0wnzpl76j64azn9p4jv5vfcrcak-activation-script.drv'...
building '/nix/store/4fx1bb8ymwi9b5dawfib9qs4fdy5vd91-alacritty.toml.drv'...
building '/nix/store/56flhrwknzyz2vfl7yw407fjy15g9ijx-appimage-run-usr-target.drv'...
building '/nix/store/55z5sxdhmqihjq914r9hn7fhjdpkxmfp-code-bwrap.drv'...
building '/nix/store/1gyqacwz41bhydifsnrgi993wn1881fz-expressvpnd-fhsenv-rootfs.drv'...
building '/nix/store/j35bs2b82gdny4bw0rb89ndwajsw1jmc-fc-cache.drv'...
building '/nix/store/c8hlm61sjni9d6yz41rik3m3cpsfmjhm-google-chrome-stable_130.0.6723.91-1_amd64.deb.drv'...
building '/nix/store/lbsf6y8wflhjfm5c0pjf8a75pydh5l40-mpv-with-scripts-0.39.0.drv'...
building '/nix/store/9g2gb3z32m4p0saa03f0y0cr6zk9gra1-openscad-2021.01-fish-completions.drv'...
building '/nix/store/fvig2bd6hfrh8njaplb84ia2f18h7mf7-openvdb-12.0.0.drv'...
building '/nix/store/0cv44icr2g4cvr9ckshsyibq1n9z7ic2-firefox-132.0.1-fish-completions.drv'...
building '/nix/store/gx888jilik70zh516gg159mspf0xf838-shutdown-ramfs-contents.json.drv'...
building '/nix/store/sq5cb4sy7ipz5j1y347nkfzn1cdcd6ls-signal-desktop-7.31.0-fish-completions.drv'...
building '/nix/store/b3sfqx4dx4fp7rbj3hj3jwc3h2lxa4zs-sops-install-secrets-0.0.1.drv'...
building '/nix/store/4fg9n552dms560s7qsqrlnzaiyapf4xd-starship-config.drv'...
building '/nix/store/02w46i89vnl3i1rzzzxx4f65cw2c7xs8-syncthing-1.28.0-fish-completions.drv'...
building '/nix/store/zd4sssk5x6lidb30i3hwbl9vaq0jldmi-syncthing.service.drv'...
error: builder for '/nix/store/1gyqacwz41bhydifsnrgi993wn1881fz-expressvpnd-fhsenv-rootfs.drv' failed with exit code 1;
       last 2 log lines:
       > structuredAttrs is enabled
       > chmod: cannot access 'sbin': No such file or directory
       For full logs, run 'nix log /nix/store/1gyqacwz41bhydifsnrgi993wn1881fz-expressvpnd-fhsenv-rootfs.drv'.
error: 1 dependencies of derivation '/nix/store/xqba5zf627x3skngv2m3qkk121f1gfyr-expressvpnd-bwrap.drv' failed to build
copying path '/nix/store/dv9jkgnn5grk05927ysszwzck25vgdwn-qemu-9.1.1' from 'https://cache.nixos.org'...
building '/nix/store/55bn152v44fw8ci4sg999w6wp7ws41a8-X-Restart-Triggers-nix-daemon.drv'...
building '/nix/store/w0zyapn9fb36p1x8jsfv117h69q12g3i-code.drv'...
error: 1 dependencies of derivation '/nix/store/04r0grdsfb7lxvb0bhk2gf7rm2imssyf-expressvpnd.drv' failed to build
building '/nix/store/ml29idfdli14iaf6mjimq90fkg3y5c2l-graphics-driver.conf.drv'...
building '/nix/store/92z2gl7wg3lnnfm081sxk7faa7ds37x0-ledger-live-desktop-2.89.1-bwrap.drv'...
building '/nix/store/n8dwa1k4cvy3nm1icrmszxk3kz1n3zkd-mpv-with-scripts-0.39.0-fish-completions.drv'...
error: 1 dependencies of derivation '/nix/store/i4xmqcqhr6ny7b20aynzk1arp2cpcgfk-expressvpn-3.52.0.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/h99qphphpc9i461fhbx0vpacnqwdlpfk-expressvpn-3.52.0.2-fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/gvq0qh6h52i8abpkj20w81xbrafxgf8r-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/gwfh9y7lbblfaaij7gmkci5h8a2hjjcl-man-paths.drv' failed to build
error: 1 dependencies of derivation '/nix/store/kcv2y7ad3wprggn4vv4dfi0cv6f9rahr-unit-expressvpn.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/6v1iw4icjz4zs0l3ck4gvwl88v1w3mlj-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/q0y6a3kgw7lwvhxvr8ybgf32pw9jj059-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/nwjssrns2fn0j6mw5ylnj3cgiilv7w79-nixos-system-hermes-24.11.20241105.4aa3656.drv' failed to build
```