### PR TITLE
Add Home Assistant ingress to Cloudflare Tunnel

### DIFF
--- a/modules/nixos/cloudflared.nix
+++ b/modules/nixos/cloudflared.nix
@@ -13,6 +13,9 @@
             "ssh-hermes.adriaan.cc" = {
               service = "ssh://127.0.0.1:22";
             };
+            "ha.adriaan.cc" = {
+              service = "http://192.168.178.113:8123";
+            };
           };
         };
       };


### PR DESCRIPTION
## Summary

Add `ha.adriaan.cc` ingress rule to the existing Hermes Cloudflare Tunnel, routing to the Home Assistant instance at `192.168.178.113:8123`.

## Prerequisites

- DNS CNAME `ha.adriaan.cc` → `e0b6e7f2-c209-4f32-b371-669a635695e1.cfargotunnel.com` (proxied) — already created via Cloudflare API.

## After merge

Rebuild Hermes:
```
sudo nixos-rebuild switch --flake .#hermes
```

Then set the HA external URL to `https://ha.adriaan.cc` and configure the companion app.